### PR TITLE
Fixing NDK code compilation error in Android Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ Precondition: make sure that you have [**NDK**][2] installed and you either have
 
 or you have `ANDROID_NDK_HOME` environment variable set.
 
+#### Getting started
+
+Just import the whole cloned project and run the sample.
+
+#### Further configuring and using as the library
+
  1. Copy `JniBitmapOperationsLibrary.cpp` into `src/main/jni` directory:
  
     ![Studio folder structure](https://s3.amazonaws.com/uploads.hipchat.com/22412/120721/qZyoFrgpUnFmnHu/upload.png)


### PR DESCRIPTION
Adding the extra empty ".c" file fixes the error with compilation from the Android Studio. 
A known bug: https://code.google.com/p/android/issues/detail?id=66937

>>This may come from a current NDK bug on Windows, when there is only one source file to compile. You only need to add one empty source to make it work again.<<
http://ph0b.com/android-studio-gradle-and-ndk-integration/