### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Just import the whole cloned project and run the sample.
  
     ```
     include ':JniBitmapOperationsLibrary'
-    project(':JniBitmapOperationsLibrary').projectDir = new File(settingsDir, '../AndroidJniBitmapOperations/JniBitmapOperationsLibrary')
+    project(':JniBitmapOperationsLibrary').projectDir = new File(rootProject.getProjectDir(), 'AndroidJniBitmapOperations/JniBitmapOperationsLibrary')
     ```
  3. Add the following lines to your top level `build.gradle` file inside the `buildscript` section. Replace the versions with whatever your project is using as needed.
  


### PR DESCRIPTION
Sorry to make another PR so quickly after the last one. However unfortunately one of the suggested Gadle lines caused issues when trying to build an a CI server that doesn’t use the typical Gradle wrapper. This updated version is more robust and works as expected without breaking.