### PR TITLE
Move minSdkVersion and targetSdkVersion to gradle

### DIFF
--- a/JniBitmapOperationsLibrary/AndroidManifest.xml
+++ b/JniBitmapOperationsLibrary/AndroidManifest.xml
@@ -1,11 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.jnibitmapoperationslibrary"
     android:versionCode="1"
-    android:versionName="1.0" >
-
-    <uses-sdk
-        android:minSdkVersion="8"
-        android:targetSdkVersion="23" />
-
-
-</manifest>
+    android:versionName="1.0" />

--- a/JniBitmapOperationsLibrary/build.gradle
+++ b/JniBitmapOperationsLibrary/build.gradle
@@ -25,6 +25,8 @@ android {
             cFlags "-DANDROID_NDK_HOME"
             stl "stlport_shared"
         }
+        minSdkVersion  8
+        targetSdkVersion 23
     }
 
     externalNativeBuild {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
The min and target SDK versions should be declared in Gradle now instead of the Manifest.

Also bumped the Gradle version.